### PR TITLE
Adds removal of the system.config

### DIFF
--- a/telegraf/config.sls
+++ b/telegraf/config.sls
@@ -23,6 +23,10 @@ telegraf-system-inputs:
     - mode: 644
     - require:
       - sls: telegraf.install
+{%- else %}
+telegraf-system-inputs:
+  file.absent:
+    - name: /etc/telegraf/telegraf.d/system.conf
 {%- endif %}
 
 {%- if telegraf.inputs is defined %}


### PR DESCRIPTION
Adds in the removal of the `system.conf` if `use_system_inputs` is not set to True. This allows it to be removed after it has been installed.